### PR TITLE
Feedback fix

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+https://honestbee.atlassian.net/browse/
+
+## WIP Checklist
+
+- [ ] JIRA link filled in
+- [ ] JIRA issue tagged with correct fix version (same as the PR milestone)
+- [ ] schema.rb is up to date. See https://github.com/honestbee/guides/issues/20 for instruction
+- [ ] New rspec tests for new code written
+- [ ] Manual testing done
+- [ ] Hound issues fixed
+- [ ] New controllers in V1 to inherited in other versions
+- [ ] ...others
+
+## Why is this change necessary?
+
+-
+
+## How does it address the issue?
+
+-
+
+## What side effects does this change have?
+
+- Performance
+- Affected client apps
+  - [ ] Inform front-end web team
+  - [ ] Inform iOS app team
+  - [ ] Inform android app team
+  - [ ] Inform hive team
+
+## Related PRs?
+
+* other_pr_production / link
+
+## Deploy Notes
+
+- Migrations:
+- Rake tasks:
+- Config (secrets in blackbox/VAULT):

--- a/app/assets/stylesheets/base/default.scss
+++ b/app/assets/stylesheets/base/default.scss
@@ -21,9 +21,6 @@ i {
   width: 26px;
 }
 
-ul {
-  list-style-type: none;
-}
 
 a:hover, a:active, a:link, a:visited {
   text-decoration: none;

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -13,7 +13,7 @@ class AssignmentsController < ApplicationController
     end
 
     @shift = Shift.find(shift_id)
-    if @shift.max_count == @shift.deliverer.count
+    if @shift.max_count == @shift.deliverers.count
       flash[:danger] = "Shift count has already maxed out!"
       redirect_to home_path
       return
@@ -42,7 +42,7 @@ class AssignmentsController < ApplicationController
       flash[:danger] = "Invalid date range!"
       redirect_to home_path
     end
-    
+
     @shifts = Shift.where(start_time: @start..@end).where(end_time: @start..@end)
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -2,33 +2,20 @@ class AssignmentsController < ApplicationController
 
   def create
     if params[:assignment].nil?
-      flash[:danger] = "Please create some Deliverers and Shifts first."
-      redirect_to home_path
-      return
-    elsif params[:assignment][:shift_id].nil? ||
-            params[:assignment][:deliverer_id].nil?
-      flash[:danger] = "Please create some Deliverers and Shifts first."
-      redirect_to home_path
-      return
-    end
-
-    @shift = Shift.find(shift_id)
-    if @shift.max_count == @shift.deliverers.count
-      flash[:danger] = "Shift count has already maxed out!"
-      redirect_to home_path
-      return
-    end
-
-    @assignment = Assignment.new(assignment_params)
-
-    if @assignment.save
-      flash[:success] = "A new assignment has been made!"
+      flash[:danger] = "No assignment received"
       redirect_to home_path
       return
     else
-      flash[:danger] = "Error in assigning shift!"
+
+      shift_assignment_service = ShiftAssignmentService.new(deliverer_id, shift_id)
+
+      if shift_assignment_service.perform
+        flash[:success] = shift_assignment_service.success
+      else
+        flash[:danger] = shift_assignment_service.errors
+      end
+
       redirect_to home_path
-      return
     end
   end
 
@@ -46,8 +33,8 @@ class AssignmentsController < ApplicationController
     @shifts = Shift.where(start_time: @start..@end).where(end_time: @start..@end)
   end
 
-  def assignment_params
-    params.require(:assignment).permit(:deliverer_id, :shift_id)
+  def deliverer_id
+    params[:assignment][:deliverer_id]
   end
   def shift_id
     params[:assignment][:shift_id]

--- a/app/controllers/deliverers_controller.rb
+++ b/app/controllers/deliverers_controller.rb
@@ -16,7 +16,7 @@ class DeliverersController < ApplicationController
     else
       errors = @deliverer.errors unless @deliverer.valid?
 
-      flash[:danger] = errors.full_messages.to_sentence
+      flash[:danger] = errors.full_messages
       redirect_to new_deliverer_path
     end
   end
@@ -35,7 +35,7 @@ class DeliverersController < ApplicationController
     else
       errors = @deliverer.errors unless @deliverer.valid?
 
-      flash[:danger] = errors.full_messages.to_sentence
+      flash[:danger] = errors.full_messages
       redirect_to edit_deliverer_path
     end
   end

--- a/app/controllers/deliverers_controller.rb
+++ b/app/controllers/deliverers_controller.rb
@@ -42,7 +42,7 @@ class DeliverersController < ApplicationController
 
 
   private
-  
+
   def deliverer_params
     params.require(:deliverer).permit(:name, :phone, :vehicle, :active)
   end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -11,7 +11,7 @@ class ShiftsController < ApplicationController
     else
       errors = @shift.errors unless @shift.valid?
 
-      flash[:danger] = errors.full_messages.to_sentence
+      flash[:danger] = errors.full_messages
       redirect_to new_shift_path
     end
   end
@@ -27,7 +27,7 @@ class ShiftsController < ApplicationController
     else
       errors = @shift.errors unless @shift.valid?
 
-      flash[:danger] = errors.full_messages.to_sentence
+      flash[:danger] = errors.full_messages
       redirect_to edit_shift_path
     end
   end

--- a/app/helpers/shared_helper.rb
+++ b/app/helpers/shared_helper.rb
@@ -1,0 +1,13 @@
+module SharedHelper
+  def flash_ul(message)
+    if message.kind_of?(Array)
+      tag.ul{
+        message.each do |m|
+          concat tag.li(m)
+        end
+      }
+    else
+      message
+    end
+  end
+end

--- a/app/models/deliverer.rb
+++ b/app/models/deliverer.rb
@@ -1,6 +1,6 @@
 class Deliverer < ApplicationRecord
-  has_many :assignment
-  has_many :shift, through: :assignment
+  has_many :assignments
+  has_many :shifts, through: :assignments
 
   validates :name, presence: { message: "Name field is empty" },
       length: { maximum: 50, message: "Name cannot be longer than 50 characters" }

--- a/app/models/deliverer.rb
+++ b/app/models/deliverer.rb
@@ -9,18 +9,7 @@ class Deliverer < ApplicationRecord
       numericality: { only_integer: true, message: "Phone has to be an integer" },
       uniqueness: { message: "Phone already in used" }
 
-  def vehicle_to_s
-    case self.vehicle
-    when 0
-      "Motorbike"
-    when 1
-      "Bicycle"
-    when 2
-      "Scooter"
-    else
-      "ERROR"
-    end
-  end
+  enum vehicle: { motorbike: 0, bicycle: 1, scooter:2 }
 
   def active_to_s
     case self.active

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,6 +1,6 @@
 class Shift < ApplicationRecord
-  has_many :assignment
-  has_many :deliverer, through: :assignment
+  has_many :assignments
+  has_many :deliverers, through: :assignments
 
   validates :start_time, presence: true,
       uniqueness: { scope: :end_time, message: "Shift already exist" }

--- a/app/services/shift_assignment_service.rb
+++ b/app/services/shift_assignment_service.rb
@@ -14,20 +14,19 @@ class ShiftAssignmentService
     # Terminate when variables are not found
     if @deliverer_id.nil? || @shift_id.nil?
       @errors << "Please create some Deliverers and Shifts first."
+      return false
     end
 
     # Check max count for Shift
     shift = Shift.find(shift_id)
     if shift.max_count == shift.deliverers.count
       @errors << "Shift count has already maxed out!"
+      return false
     end
 
     # Check if Shift already exist
     if Assignment.exists?(deliverer_id: @deliverer_id, shift_id: @shift_id)
       @errors << "Assignment already exist!"
-    end
-
-    if !@errors.empty?
       return false
     end
 

--- a/app/services/shift_assignment_service.rb
+++ b/app/services/shift_assignment_service.rb
@@ -19,7 +19,7 @@ class ShiftAssignmentService
 
     # Check max count for Shift
     shift = Shift.find(shift_id)
-    if shift.max_count == shift.deliverers.count
+    if shift.max_count <= shift.deliverers.count
       @errors << "Shift count has already maxed out!"
       return false
     end

--- a/app/services/shift_assignment_service.rb
+++ b/app/services/shift_assignment_service.rb
@@ -1,0 +1,50 @@
+class ShiftAssignmentService
+
+  attr_reader :deliverer_id, :shift_id, :errors, :success
+
+  def initialize(deliverer_id, shift_id)
+    @deliverer_id = deliverer_id
+    @shift_id = shift_id
+    @errors = []
+    @success = []
+  end
+
+  def perform
+
+    # Terminate when variables are not found
+    if @deliverer_id.nil? || @shift_id.nil?
+      @errors << "Please create some Deliverers and Shifts first."
+    end
+
+    # Check max count for Shift
+    shift = Shift.find(shift_id)
+    if shift.max_count == shift.deliverers.count
+      @errors << "Shift count has already maxed out!"
+    end
+
+    # Check if Shift already exist
+    if Assignment.exists?(deliverer_id: @deliverer_id, shift_id: @shift_id)
+      @errors << "Assignment already exist!"
+    end
+
+    if !@errors.empty?
+      return false
+    end
+
+    assignment = Assignment.new(
+      deliverer_id: @deliverer_id,
+      shift_id: @shift_id
+    )
+
+    if assignment.save
+      @success << "A new assignment has been made!"
+
+      return true
+    else
+      @errors << "Error in assigning shift!"
+
+      return false
+    end
+  end
+
+end

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -21,10 +21,10 @@
             <th><%= shift.id %></th>
             <td><%= link_to shift.start_time_to_s, edit_shift_path(shift) %></td>
             <td><%= shift.end_time_to_s %></td>
-            <td><%= "#{shift.deliverer.count}/#{shift.max_count}" %></td>
+            <td><%= "#{shift.deliverers.count}/#{shift.max_count}" %></td>
           </tr>
 
-          <% if shift.deliverer.count != 0 %>
+          <% if shift.deliverers.count != 0 %>
             <tr>
               <th></th>
               <th>Deliverer ID</th>
@@ -32,7 +32,7 @@
               <th>Phone</th>
             </tr>
 
-            <% shift.deliverer.each do |d| %>
+            <% shift.deliverers.each do |d| %>
               <tr>
                 <td></td>
                 <td><%= d.id %></td>

--- a/app/views/deliverers/edit.html.erb
+++ b/app/views/deliverers/edit.html.erb
@@ -1,8 +1,8 @@
-<div class="container" id="sign-up-form">
+<div class="container">
   <div class="row">
 
 
-    <div class="col-sm-offset-4 col-sm-4">
+    <div class="col-md-offset-2 col-md-8">
       <h3>Update Deliverer</h3>
 
       <%= bootstrap_form_for(@deliverer) do |f| %>

--- a/app/views/deliverers/edit.html.erb
+++ b/app/views/deliverers/edit.html.erb
@@ -20,7 +20,7 @@
 	           class: 'form-control' %>
 
         <%= f.label :vehicle %>
-        <%= f.select :vehicle, [['Motorcycle',0], ['Bicycle',1], ['Scooter',2]], {} %>
+        <%= f.select :vehicle, Deliverer.vehicles.keys.map { |w| [w.capitalize, w] } %>
 
         <%= f.label :active %>
         <%= f.check_box :active %>

--- a/app/views/deliverers/new.html.erb
+++ b/app/views/deliverers/new.html.erb
@@ -1,8 +1,8 @@
-<div class="container" id="sign-up-form">
+<div class="container">
   <div class="row">
 
 
-    <div class="col-sm-offset-4 col-sm-4">
+    <div class="col-md-offset-2 col-md-8">
       <h3>Create Deliverer</h3>
 
       <%= bootstrap_form_for(@deliverer) do |f| %>

--- a/app/views/deliverers/new.html.erb
+++ b/app/views/deliverers/new.html.erb
@@ -21,7 +21,7 @@
 	           class: 'form-control' %>
 
         <%= f.label :vehicle %>
-        <%= f.select :vehicle, [['Motorcycle',0], ['Bicycle',1], ['Scooter',2]], {} %>
+        <%= f.select :vehicle, Deliverer.vehicles.keys.map { |w| [w.capitalize, w] } %>
 
         <%= f.label :active %>
         <%= f.check_box :active %>

--- a/app/views/pages/_deliverers_table.html.erb
+++ b/app/views/pages/_deliverers_table.html.erb
@@ -14,7 +14,7 @@
       <th><%= deliverer.id %></th>
       <td><%= link_to deliverer.name, edit_deliverer_path(deliverer) %></td>
       <td><%= deliverer.phone %></td>
-      <td><%= deliverer.vehicle_to_s %></td>
+      <td><%= deliverer.vehicle.capitalize %></td>
       <td><%= deliverer.active_to_s %></td>
     </tr>
   <% end %>

--- a/app/views/pages/_shift_assignment_form.html.erb
+++ b/app/views/pages/_shift_assignment_form.html.erb
@@ -1,4 +1,4 @@
-<div id="sign-up-form">
+<div>
   <h3>Shifts Assignment</h3>
 
   <%= bootstrap_form_for(@assignment) do |f| %>

--- a/app/views/pages/_shifts_table.html.erb
+++ b/app/views/pages/_shifts_table.html.erb
@@ -14,7 +14,7 @@
       <th><%= shift.id %></th>
       <td><%= link_to shift.start_time_to_s, edit_shift_path(shift) %></td>
       <td><%= shift.end_time_to_s %></td>
-      <td><%= "#{shift.deliverer.count}/#{shift.max_count}" %></td>
+      <td><%= "#{shift.deliverers.count}/#{shift.max_count}" %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/pages/_view_assignment_form.html.erb
+++ b/app/views/pages/_view_assignment_form.html.erb
@@ -1,4 +1,4 @@
-<div id="sign-up-form">
+<div>
   <h3>View Assignment</h3>
 
   <%= bootstrap_form_for(@assignment, :url => assignments_show_path) do |f| %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,4 +1,6 @@
 <% flash.each do |key, value| %>
   <br>
-  <div class="alert alert-<%= key %>"><%= value %></div>
+  <div class="alert alert-<%= key %>">
+    <%= flash_ul(value) %>
+  </div>
 <% end %>

--- a/app/views/shifts/edit.html.erb
+++ b/app/views/shifts/edit.html.erb
@@ -1,8 +1,8 @@
-<div class="container" id="sign-up-form">
+<div class="container">
   <div class="row">
 
 
-    <div class="col-sm-offset-4 col-sm-4">
+    <div class="col-md-offset-2 col-md-8">
       <h3>Update Shift</h3>
 
       <%= render 'shared/flash_messages' %>

--- a/app/views/shifts/new.html.erb
+++ b/app/views/shifts/new.html.erb
@@ -1,8 +1,8 @@
-<div class="container" id="sign-up-form">
+<div class="container">
   <div class="row">
 
 
-    <div class="col-sm-offset-4 col-sm-4">
+    <div class="col-md-offset-2 col-md-8">
       <h3>Create Shift</h3>
 
       <%= render 'shared/flash_messages' %>
@@ -33,7 +33,7 @@
        	          class: 'form-control' %></td>
         </tr>
       </table>
-      
+
         <%= f.submit 'Create', class: 'btn sign-up-button' %>
       <% end %>
     </div>

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe AssignmentsController, type: :controller do
           # Match Shift info
           expect(response.body).to match("#{@shift.start_time_to_s}")
           expect(response.body).to match("#{@shift.end_time_to_s}")
-          expect(response.body).to match("#{@shift.deliverer.count}/#{@shift.max_count}")
+          expect(response.body).to match("#{@shift.deliverers.count}/#{@shift.max_count}")
 
           # Match Deliverer info within Shift
           expect(response.body).to match("#{@deliverer.id}")

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -23,19 +23,7 @@ RSpec.describe AssignmentsController, type: :controller do
       end
     end
 
-    context "when no deliverer_id in param" do
-      it "redirects to home_path and flashes danger" do
-        post :create, params: {
-          assignment: {
-            shift_id: @shift.id
-          }
-        }
-
-        is_expected.to set_flash[:danger]
-      end
-    end
-
-    context "when no shift_id in param" do
+    context "when assignment service failure" do
       it "redirects to home_path and flashes danger" do
         post :create, params: {
           assignment: {
@@ -44,10 +32,11 @@ RSpec.describe AssignmentsController, type: :controller do
         }
 
         is_expected.to set_flash[:danger]
+        is_expected.to redirect_to home_path
       end
     end
 
-    context "with valid attributes" do
+    context "when assignment service success" do
       it "creates a new assignment" do
         post :create,
           params: {
@@ -59,46 +48,7 @@ RSpec.describe AssignmentsController, type: :controller do
 
         is_expected.to set_flash[:success]
         is_expected.to redirect_to home_path
-      end
-    end
 
-    context "with invalid attributes" do
-      it "flash danger" do
-        post :create,
-          params: {
-            assignment: {
-              deliverer_id: -1,
-              shift_id: @shift.id
-            }
-          }
-
-        is_expected.to set_flash[:danger].to("Error in assigning shift!")
-        is_expected.to redirect_to home_path
-      end
-    end
-
-    context "when shift has maxed out" do
-      it "flash danger" do
-        # Initial insertion: 0/1 -> 1/1
-        post :create,
-          params: {
-            assignment: {
-              deliverer_id: @deliverer[0].id,
-              shift_id: @shift.id
-            }
-          }
-
-        # Insertion to an already maxed out shift
-        post :create,
-          params: {
-            assignment: {
-              deliverer_id: @deliverer[1].id,
-              shift_id: @shift.id
-            }
-          }
-
-        is_expected.to set_flash[:danger].to("Shift count has already maxed out!")
-        is_expected.to redirect_to home_path
       end
     end
   end

--- a/spec/controllers/deliverers_controller_spec.rb
+++ b/spec/controllers/deliverers_controller_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe DeliverersController, type: :controller do
       it "creates new deliverer" do
         expect{
           post :create,
-          params: { deliverer: FactoryGirl.attributes_for(:deliverer) }
+          params: { deliverer: FactoryGirl.attributes_for(:deliverer) },
+          as: :json
         }.to change{ Deliverer.count }.by(1)
 
         is_expected.to redirect_to home_path
@@ -33,7 +34,8 @@ RSpec.describe DeliverersController, type: :controller do
 
     context "with invalid attributes" do
       it "redirects to #new with flash danger" do
-        expect{ post :create,
+        expect{
+          post :create,
           params: {
             deliverer: {
               name: "My Name",
@@ -41,7 +43,8 @@ RSpec.describe DeliverersController, type: :controller do
               phone: "a",
               active: false
             }
-          }
+          },
+          as: :json
         }.to change{ Deliverer.count }.by(0)
 
         is_expected.to set_flash[:danger]
@@ -57,7 +60,7 @@ RSpec.describe DeliverersController, type: :controller do
       @deliverer = FactoryGirl.create(:deliverer)
 
       get :edit, params: { :id => @deliverer.id }
-      
+
       expect(@deliverer).to eq(assigns(:deliverer))
 
     end
@@ -72,10 +75,12 @@ RSpec.describe DeliverersController, type: :controller do
     context "with valid attributes" do
       it "update deliverer's attributes" do
 
-        patch :update, params: {
-          :id => @deliverer.id,
-          deliverer: FactoryGirl.attributes_for(:deliverer)
-        }
+        patch :update,
+          params: {
+            :id => @deliverer.id,
+            deliverer: FactoryGirl.attributes_for(:deliverer)
+          },
+          as: :json
 
         is_expected.to redirect_to home_path
       end
@@ -93,7 +98,8 @@ RSpec.describe DeliverersController, type: :controller do
               phone: "a",
               active: false
             }
-          }
+          },
+          as: :json
 
         is_expected.to set_flash[:danger]
         is_expected.to redirect_to edit_deliverer_path

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PagesController, type: :controller do
           expect(response.body).to match("#{d.id}")
           expect(response.body).to match("#{d.name}")
           expect(response.body).to match("#{d.phone}")
-          expect(response.body).to match("#{d.vehicle_to_s}")
+          expect(response.body).to match("#{d.vehicle.capitalize}")
           expect(response.body).to match("#{d.active_to_s}")
         end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe PagesController, type: :controller do
           expect(response.body).to match("#{s.id}")
           expect(response.body).to match("#{s.start_time_to_s}")
           expect(response.body).to match("#{s.end_time_to_s}")
-          expect(response.body).to match("#{s.deliverer.count}/#{s.max_count}")
+          expect(response.body).to match("#{s.deliverers.count}/#{s.max_count}")
         end
       end
     end

--- a/spec/factories/shifts.rb
+++ b/spec/factories/shifts.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :shift do
     sequence(:start_time) { |n| (DateTime.parse("2018-05-23 10:00:00") + (n*2).hours).strftime("%Y-%m-%d %T") }
     sequence(:end_time) { |n| (DateTime.parse("2018-05-23 12:00:00") + (n*2).hours).strftime("%Y-%m-%d %T") }
-    max_count 1
+    max_count 2
   end
 end

--- a/spec/helpers/shared_helper_spec.rb
+++ b/spec/helpers/shared_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SharedHelper, :type => :helper do
+
+  describe "#flash_ul" do
+    context "when message is array" do
+      it "returns an unordered list" do
+        expect(
+          helper.flash_ul(["message1","message2","message3"])
+        ).to eq(
+          "<ul><li>message1</li><li>message2</li><li>message3</li></ul>"
+        )
+      end
+    end
+
+    context "when message is a string" do
+      it "returns the string" do
+        expect(helper.flash_ul("message")).to eq("message")
+      end
+    end
+  end
+
+end

--- a/spec/models/deliverer_spec.rb
+++ b/spec/models/deliverer_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe Deliverer, type: :model do
 
   # Test association
-  it { is_expected.to have_many(:assignment) }
-  it { is_expected.to have_many(:shift).through(:assignment) }
+  it { is_expected.to have_many(:assignments) }
+  it { is_expected.to have_many(:shifts).through(:assignments) }
 
   # Test Name attribute
   it { is_expected.to validate_presence_of(:name).

--- a/spec/models/deliverer_spec.rb
+++ b/spec/models/deliverer_spec.rb
@@ -28,32 +28,6 @@ RSpec.describe Deliverer, type: :model do
 
   subject { Deliverer.new }
 
-  describe '#vehicle_to_s' do
-    context 'when vehicle index 0' do
-      it 'returns Motorbike' do
-        subject.vehicle = 0
-
-        expect(subject.vehicle_to_s).to eq("Motorbike")
-      end
-    end
-
-    context 'when vehicle index 1' do
-      it 'returns Bicycle' do
-        subject.vehicle = 1
-
-        expect(subject.vehicle_to_s).to eq("Bicycle")
-      end
-    end
-
-    context 'when vehicle index 2' do
-      it 'returns Scooter' do
-        subject.vehicle = 2
-
-        expect(subject.vehicle_to_s).to eq("Scooter")
-      end
-    end
-  end
-
   describe '#active_helper' do
     context 'when active true' do
       it 'returns Active' do

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Shift, type: :model do
     max_count: 10) }
 
   # Test association
-  it { is_expected.to have_many(:assignment) }
-  it { is_expected.to have_many(:deliverer).through(:assignment) }
+  it { is_expected.to have_many(:assignments) }
+  it { is_expected.to have_many(:deliverers).through(:assignments) }
 
   # Test Start time attribute
   it { is_expected.to validate_presence_of(:start_time) }

--- a/spec/services/shift_assignment_service_spec.rb
+++ b/spec/services/shift_assignment_service_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe ShiftAssignmentService do
     before do
       @deliverers = FactoryGirl.create_list(:deliverer,3)
       @shift = FactoryGirl.create(:shift)
-
-      @service1 = ShiftAssignmentService.new(@deliverers[0].id, @shift.id)
     end
 
     subject { ShiftAssignmentService.new }
@@ -33,12 +31,19 @@ RSpec.describe ShiftAssignmentService do
     context "when Shift is already maxed out" do
       before do
         # Setup services to be assigned
-        @service2 = ShiftAssignmentService.new(@deliverers[1].id, @shift.id)
         @service3 = ShiftAssignmentService.new(@deliverers[2].id, @shift.id)
 
         # Max out Shift: 0/2 -> 2/2
-        @service1.perform
-        @service2.perform
+        @service1 = FactoryGirl.create(
+          :assignment,
+          deliverer_id: @deliverers[0].id,
+          shift_id: @shift.id
+        )
+        @service2 = FactoryGirl.create(
+          :assignment,
+          deliverer_id: @deliverers[1].id,
+          shift_id: @shift.id
+        )
       end
 
       it "adds to error" do
@@ -50,6 +55,7 @@ RSpec.describe ShiftAssignmentService do
     context "when Assignment already exist" do
       before do
         # Add pre-existing service
+        @service1 = ShiftAssignmentService.new(@deliverers[0].id, @shift.id)
         @service1.perform
       end
 
@@ -73,6 +79,9 @@ RSpec.describe ShiftAssignmentService do
     end
 
     context "when successful" do
+      before do
+        @service1 = ShiftAssignmentService.new(@deliverers[0].id, @shift.id)
+      end
       it "adds to success" do
         expect(@service1.perform).to eq(true)
         expect(@service1.success).to include("A new assignment has been made!")

--- a/spec/services/shift_assignment_service_spec.rb
+++ b/spec/services/shift_assignment_service_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe ShiftAssignmentService do
+
+  describe "#perform" do
+    before do
+      @deliverers = FactoryGirl.create_list(:deliverer,3)
+      @shift = FactoryGirl.create(:shift)
+
+      @service1 = ShiftAssignmentService.new(@deliverers[0].id, @shift.id)
+    end
+
+    subject { ShiftAssignmentService.new }
+
+    context "when deliverer or shift id is nil" do
+      before do
+        # Setup erroneous services
+        @service_deliverer_nil = ShiftAssignmentService.new(nil, @shift.id)
+        @service_shift_nil = ShiftAssignmentService.new(@deliverers[0].id, nil)
+      end
+
+      it "adds to errors" do
+
+        expect(@service_deliverer_nil.perform).to eq(false)
+        expect(@service_deliverer_nil.errors).to include("Please create some Deliverers and Shifts first.")
+
+        expect(@service_shift_nil.perform).to eq(false)
+        expect(@service_shift_nil.errors).to include("Please create some Deliverers and Shifts first.")
+
+      end
+    end
+
+    context "when Shift is already maxed out" do
+      before do
+        # Setup services to be assigned
+        @service2 = ShiftAssignmentService.new(@deliverers[1].id, @shift.id)
+        @service3 = ShiftAssignmentService.new(@deliverers[2].id, @shift.id)
+
+        # Max out Shift: 0/2 -> 2/2
+        @service1.perform
+        @service2.perform
+      end
+
+      it "adds to error" do
+        expect(@service3.perform).to eq(false)
+        expect(@service3.errors).to include("Shift count has already maxed out!")
+      end
+    end
+
+    context "when Assignment already exist" do
+      before do
+        # Add pre-existing service
+        @service1.perform
+      end
+
+      it "adds to error" do
+        expect(@service1.perform).to eq(false)
+        expect(@service1.errors).to include("Assignment already exist!")
+      end
+    end
+
+    context "when error in saving" do
+      before do
+        # Setup erroneous services
+        @service_erroneous = ShiftAssignmentService.new(-1, @shift.id)
+      end
+
+      it "adds to error" do
+        expect(@service_erroneous.perform).to eq(false)
+        expect(@service_erroneous.errors).to include("Error in assigning shift!")
+
+      end
+    end
+
+    context "when successful" do
+      it "adds to success" do
+        expect(@service1.perform).to eq(true)
+        expect(@service1.success).to include("A new assignment has been made!")
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
https://trello.com/c/x31hzqAO

## Why is this change necessary?

- Naming conventions: we should use plural nouns for has_many relationships
- Use enum for vehicle type. Should not hard code vehicle type in view
- Use a service object for shift assignment logic

## What side effects does this change have?

- New service is created: ShiftAssignmentService
- New spec is created for ShiftAssignmentService
- New helper added to handle multiple flash messages
