### PR TITLE
Optimize Pages for performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'factory_girl_rails'
 gem 'database_cleaner'
 gem 'rails-controller-testing'
 gem 'coveralls'
+gem 'bullet'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -38,14 +38,15 @@ gem 'jbuilder', '~> 2.5'
 
 # Added for project
 gem 'devise'
-gem 'shoulda-matchers', '~> 3.0'
-gem 'rspec-rails', '~> 3.6'
-gem 'rspec-given'
-gem 'factory_girl_rails'
-gem 'database_cleaner'
-gem 'rails-controller-testing'
-gem 'coveralls'
-gem 'bullet'
+gem 'scout_apm'
+gem 'bullet',                       group: [:development, :test]
+gem 'shoulda-matchers', '~> 3.0',   group: :test
+gem 'rspec-rails', '~> 3.6',        group: :test
+gem 'rspec-given',                  group: :test
+gem 'factory_girl_rails',           group: :test
+gem 'database_cleaner',             group: :test
+gem 'rails-controller-testing',     group: :test
+gem 'coveralls',                    group: :test
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scout_apm (2.1.29)
     selenium-webdriver (3.12.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
@@ -293,6 +294,7 @@ DEPENDENCIES
   rspec-given
   rspec-rails (~> 3.6)
   sass-rails (>= 3.2)
+  scout_apm
   selenium-webdriver
   shoulda-matchers (~> 3.0)
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,9 @@ GEM
       sass (>= 3.3.4)
     bootstrap_form (2.7.0)
     builder (3.2.3)
+    bullet (5.7.5)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11.0)
     byebug (10.0.2)
     capybara (2.18.0)
       addressable
@@ -252,6 +255,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    uniform_notifier (1.11.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.6.2)
@@ -271,6 +275,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   bootstrap_form
+  bullet
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)

--- a/app/assets/stylesheets/base/default.scss
+++ b/app/assets/stylesheets/base/default.scss
@@ -4,6 +4,7 @@
 
 html {
   font-size: 62.5%;
+  overflow-y: scroll;
 }
 
 body {
@@ -20,7 +21,6 @@ h1 {
 i {
   width: 26px;
 }
-
 
 a:hover, a:active, a:link, a:visited {
   text-decoration: none;

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -67,6 +67,6 @@ class AssignmentsController < ApplicationController
 
   # :reek:UtilityFunction
   def retrieve_shift_in_range(range)
-    Shift.where(start_time: range).where(end_time: range)
+    Shift.where(start_time: range).where(end_time: range).includes(:deliverers)
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,6 +1,6 @@
 class Assignment < ApplicationRecord
-  belongs_to :deliverer
-  belongs_to :shift
+  belongs_to :deliverer, counter_cache: :shifts_count
+  belongs_to :shift, counter_cache: :deliverers_count
 
   validates :deliverer_id, uniqueness: { scope: :shift_id, message: 'Assignment already exist' }
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -40,6 +40,6 @@ class Shift < ApplicationRecord
   end
 
   def max?
-    max_count <= deliverers.count
+    max_count <= deliverers_count
   end
 end

--- a/app/views/assignments/_assignment_table.html.erb
+++ b/app/views/assignments/_assignment_table.html.erb
@@ -17,10 +17,10 @@
       <th><%= shift.id %></th>
       <td><%= link_to shift.start_time_to_s, edit_shift_path(shift) %></td>
       <td><%= shift.end_time_to_s %></td>
-      <td><%= "#{shift.deliverers.count}/#{shift.max_count}" %></td>
+      <td><%= "#{shift.deliverers_count}/#{shift.max_count}" %></td>
     </tr>
 
-    <% if shift.deliverers.count != 0 %>
+    <% if shift.deliverers_count != 0 %>
       <tr>
         <td></td>
 

--- a/app/views/assignments/new.html.erb
+++ b/app/views/assignments/new.html.erb
@@ -10,7 +10,7 @@
         <%= f.select :deliverer_id, @deliverers.map{ |d| ["#{d.id} - #{d.name} - #{d.phone}", d.id] } %>
         <%= f.select :shift_id,
           @shifts.map{ |s|
-            ["#{s.id} - #{s.start_time_to_s} (#{s.deliverers.count}/#{s.max_count})", s.id]
+            ["#{s.id} - #{s.start_time_to_s} (#{s.deliverers_count}/#{s.max_count})", s.id]
           }
         %>
 

--- a/app/views/shifts/_shifts_table.html.erb
+++ b/app/views/shifts/_shifts_table.html.erb
@@ -14,7 +14,7 @@
       <th><%= shift.id %></th>
       <td><%= link_to shift.start_time_to_s, edit_shift_path(shift) %></td>
       <td><%= shift.end_time_to_s %></td>
-      <td><%= "#{shift.deliverers.count}/#{shift.max_count}" %></td>
+      <td><%= "#{shift.deliverers_count}/#{shift.max_count}" %></td>
     </tr>
   <% end %>
 </table>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,14 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Bullet configurations
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+    Bullet.add_footer = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,11 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Bullet configurations
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true # raise an error if n+1 query occurs
+  end
 end

--- a/db/migrate/20180618061506_add_counter_cache.rb
+++ b/db/migrate/20180618061506_add_counter_cache.rb
@@ -1,0 +1,21 @@
+class AddCounterCache < ActiveRecord::Migration[5.1]
+  def change
+    add_column :deliverers, :shifts_count, :integer
+    add_column :shifts, :deliverers_count, :integer
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL.squish
+          UPDATE deliverers
+             SET shifts_count = (SELECT count(*)
+                                   FROM assignments
+                                  WHERE assignments.deliverer_id = deliverers.id);
+          UPDATE shifts
+             SET deliverers_count = (SELECT count(*)
+                                       FROM assignments
+                                      WHERE assignments.shift_id = shifts.id);
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20180618061506_add_counter_cache.rb
+++ b/db/migrate/20180618061506_add_counter_cache.rb
@@ -1,7 +1,7 @@
 class AddCounterCache < ActiveRecord::Migration[5.1]
   def change
-    add_column :deliverers, :shifts_count, :integer
-    add_column :shifts, :deliverers_count, :integer
+    add_column :deliverers, :shifts_count, :integer, default: 0
+    add_column :shifts, :deliverers_count, :integer, default: 0
 
     reversible do |dir|
       dir.up do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180523022601) do
+ActiveRecord::Schema.define(version: 20180618061506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,10 +25,12 @@ ActiveRecord::Schema.define(version: 20180523022601) do
   create_table "deliverers", force: :cascade do |t|
     t.string "name"
     t.integer "vehicle"
-    t.integer "phone"
+    t.string "phone"
     t.boolean "active"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "email"
+    t.integer "shifts_count"
   end
 
   create_table "shifts", force: :cascade do |t|
@@ -37,6 +39,7 @@ ActiveRecord::Schema.define(version: 20180523022601) do
     t.integer "max_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "deliverers_count"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20180618061506) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "email"
-    t.integer "shifts_count"
+    t.integer "shifts_count", default: 0
   end
 
   create_table "shifts", force: :cascade do |t|
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 20180618061506) do
     t.integer "max_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "deliverers_count"
+    t.integer "deliverers_count", default: 0
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe AssignmentsController, type: :controller do
         And { expect(response.body).to match(shift.end_time_to_s.to_s) }
         And do
           expect(response.body).to match(
-            "#{shift.deliverers.count}/#{shift.max_count}"
+            "#{shift.deliverers_count}/#{shift.max_count}"
           )
         end
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -120,6 +120,9 @@ RSpec.describe AssignmentsController, type: :controller do
         And { expect(response.body).to match(shift.start_time_to_s.to_s) }
         And { expect(response.body).to match(shift.end_time_to_s.to_s) }
         And do
+          # Reloads shift to get updated counter cache (0 -> 1)
+          # since Assignment is created at a later point
+          shift.reload
           expect(response.body).to match(
             "#{shift.deliverers_count}/#{shift.max_count}"
           )

--- a/spec/controllers/shifts_controller_spec.rb
+++ b/spec/controllers/shifts_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ShiftsController, type: :controller do
           expect(response.body).to match(s.id.to_s)
           expect(response.body).to match(s.start_time_to_s.to_s)
           expect(response.body).to match(s.end_time_to_s.to_s)
-          expect(response.body).to match("#{s.deliverers.count}/#{s.max_count}")
+          expect(response.body).to match("#{s.deliverers_count}/#{s.max_count}")
         end
       end
     end

--- a/spec/factories/deliverers.rb
+++ b/spec/factories/deliverers.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     vehicle 1
     sequence(:phone) { |n| ((n + 9_000_001)).to_s }
     active false
+    shifts_count 0
   end
 end

--- a/spec/factories/shifts.rb
+++ b/spec/factories/shifts.rb
@@ -9,5 +9,6 @@ FactoryGirl.define do
         (n * 2).hours).strftime('%Y-%m-%d %T')
     end
     max_count 2
+    deliverers_count 0
   end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -84,11 +84,7 @@ RSpec.describe Shift, type: :model do
     end
 
     context 'when shift maxed' do
-      When do
-        allow_any_instance_of(Shift).to(
-          receive_message_chain(:deliverers, :count).and_return(2)
-        )
-      end
+      When { allow_any_instance_of(Shift).to(receive(:deliverers_count).and_return(2)) }
 
       Then { expect(shift.max?).to eq(true) }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,5 @@
 require 'factory_girl_rails'
 
-
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'active_record'
+require 'bullet'
+
 require 'coveralls'
 require 'simplecov'
 
@@ -105,4 +108,15 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/dP7pylRg

## Why is this change necessary?

- Page may run slow due to N+1 queries and inefficient querying of count

## How does it address the issue?

- Count cache has been implemented for association model
    - Delivererer has `shifts_count`
    - Shift has `deliverers_count`

## What side effects does this change have?

- Performance
    - Improve runtime of Assignment index page due to addition of `includes`
    - Counter cache prevents the need of executing a ```COUNT``` SQL operation when counting between associated models

## Deploy Notes

- Migrations:
    - `shifts_count` added to Deliverers table
    - `deliverers_count` added to Shifts table
