### PR TITLE
Public API to show available shifts

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,4 +1,24 @@
 class AssignmentsController < ApplicationController
+  # rubocop:disable Metrics/AbcSize
+  # :reek:TooManyStatements
+  # :reek:NilCheck
+  # :reek:DuplicateMethodCall
+  def index
+    @range = if !params.has_key?(:range1) || !params.has_key?(:range2)
+               Time.zone.today.at_beginning_of_day..Time.zone.today.at_end_of_day
+             else
+               date_range(params[:range1], params[:range2])
+             end
+
+    if @range.max == nil
+      flash[:danger] = 'Invalid date range!'
+      redirect_to assignments_path
+    end
+
+    @shifts = retrieve_shift_in_range(@range)
+  end
+  # rubocop:enable Metrics/AbcSize
+
   def new
     @deliverers = Deliverer.order(name: :asc, phone: :asc).all
     @shifts = Shift.order(start_time: :asc).all
@@ -22,26 +42,6 @@ class AssignmentsController < ApplicationController
 
     redirect_to new_assignment_path
   end
-
-  # rubocop:disable Metrics/AbcSize
-  # :reek:TooManyStatements
-  # :reek:NilCheck
-  # :reek:DuplicateMethodCall
-  def index
-    @range = if !params.has_key?(:range1) || !params.has_key?(:range2)
-               Time.zone.today.at_beginning_of_day..Time.zone.today.at_end_of_day
-             else
-               date_range(params[:range1], params[:range2])
-             end
-
-    if @range.max == nil
-      flash[:danger] = 'Invalid date range!'
-      redirect_to assignments_path
-    end
-
-    @shifts = retrieve_shift_in_range(@range)
-  end
-  # rubocop:enable Metrics/AbcSize
 
   def deliverer_id
     params[:assignment][:deliverer_id]

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -40,6 +40,16 @@ class ShiftsController < ApplicationController
     end
   end
 
+  def available_shifts
+    if !params.has_key?(:start_time) || !params.has_key?(:end_time)
+      render json: { status: 'Error: Missing arguments' }
+      return
+    end
+
+    api = AvailableShiftsApi.new(params[:start_time], params[:end_time])
+    render json: api.perform, except: [:created_at, :updated_at]
+  end
+
   private
 
   def shift_params

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -1,4 +1,6 @@
 class ShiftsController < ApplicationController
+  skip_before_action :authenticate_user!, only: :available_shifts
+
   def index
     @shifts = Shift.all
   end

--- a/app/services/api/available_shifts_api.rb
+++ b/app/services/api/available_shifts_api.rb
@@ -1,0 +1,24 @@
+class AvailableShiftsApi
+  def initialize(to_input, from_input)
+    @to_input = to_input
+    @from_input = from_input
+  end
+
+  # :reek:TooManyStatements
+  # :reek:NilCheck
+  def perform
+    # Catch invalid input
+    begin
+      range = Date.parse(@to_input).at_beginning_of_day..Date.parse(@from_input).at_end_of_day
+    rescue ArgumentError
+      return { status: 'Error: Invalid arguments' }
+    end
+
+    return { status: 'Error: Invalid date range' } if range.max.nil?
+
+    # Extract shifts in range
+    shifts = Shift.where(start_time: range).where(end_time: range)
+    shifts = shifts.reject(&:max?)
+    { status: 'OK', shifts: shifts }
+  end
+end

--- a/app/services/api/available_shifts_api.rb
+++ b/app/services/api/available_shifts_api.rb
@@ -1,7 +1,7 @@
 class AvailableShiftsApi
-  def initialize(to_input, from_input)
-    @to_input = to_input
+  def initialize(from_input, to_input)
     @from_input = from_input
+    @to_input = to_input
   end
 
   # :reek:TooManyStatements
@@ -9,7 +9,7 @@ class AvailableShiftsApi
   def perform
     # Catch invalid input
     begin
-      range = Date.parse(@to_input).at_beginning_of_day..Date.parse(@from_input).at_end_of_day
+      range = Date.parse(@from_input).at_beginning_of_day..Date.parse(@to_input).at_end_of_day
     rescue ArgumentError
       return { status: 'Error: Invalid arguments' }
     end

--- a/app/services/api/available_shifts_api.rb
+++ b/app/services/api/available_shifts_api.rb
@@ -19,6 +19,7 @@ class AvailableShiftsApi
     # Extract shifts in range
     shifts = Shift.where(start_time: range).where(end_time: range)
     shifts = shifts.reject(&:max?)
+
     { status: 'OK', shifts: shifts }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ module Shiftassignment
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-
     config.action_controller.include_all_helpers = true
+    config.autoload_paths += [Rails.root.join('app', 'services', 'api')]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,6 @@ Rails.application.routes.draw do
   resources :shifts, only: %i[index new create edit update]
 
   resources :assignments, only: %i[index new create]
+
+  get '/api/available_shifts', to: 'shifts#available_shifts'
 end

--- a/spec/controllers/shifts_controller_spec.rb
+++ b/spec/controllers/shifts_controller_spec.rb
@@ -123,4 +123,32 @@ RSpec.describe ShiftsController, type: :controller do
       And { is_expected.to redirect_to edit_shift_path }
     end
   end
+
+  # Test /api/available_shifts
+  describe 'get #available_shifts' do
+    Given!(:shift) { FactoryGirl.create(:shift) }
+
+    context 'missing params' do
+      When { get :available_shifts }
+      When(:json) { JSON.parse(response.body) }
+
+      Then { expect(json['status']).to eq 'Error: Missing arguments' }
+    end
+
+    context 'successful call' do
+      When do
+        get :available_shifts,
+            params: {
+              start_time: '2016-05-23',
+              end_time: '2019-05-23'
+            }
+      end
+
+      When(:json) { JSON.parse(response.body) }
+
+      # ID comparison is used as expected json object is result of render
+      Then { expect(json['status']).to eq 'OK' }
+      And { expect(json['shifts'][0]['id']).to eq shift.id }
+    end
+  end
 end

--- a/spec/services/available_shifts_api_spec.rb
+++ b/spec/services/available_shifts_api_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe AvailableShiftsApi do
+  describe '#perform' do
+    Given!(:shift) { FactoryGirl.create(:shift) }
+
+    context 'invalid argument' do
+      Then do
+        expect(AvailableShiftsApi.new('', '').perform).to(
+          eq(status: 'Error: Invalid arguments')
+        )
+      end
+      And do
+        expect(AvailableShiftsApi.new('2018-05-24', '').perform).to(
+          eq(status: 'Error: Invalid arguments')
+        )
+      end
+      And do
+        expect(AvailableShiftsApi.new('', '2018-05-24').perform).to(
+          eq(status: 'Error: Invalid arguments')
+        )
+      end
+    end
+
+    context 'invalid range' do
+      Then do
+        expect(AvailableShiftsApi.new('2019-05-24', '2018-05-24').perform).to(
+          eq(status: 'Error: Invalid date range')
+        )
+      end
+    end
+
+    context 'output not empty' do
+      When(:output) { AvailableShiftsApi.new('2018-05-25', '2018-05-25').perform }
+
+      Then { expect(output[:status]).to eq 'OK' }
+      And { expect(output[:shifts]).to eq [shift] }
+    end
+
+    context 'output empty' do
+      context 'not in range' do
+        When(:output) { AvailableShiftsApi.new('2019-05-25', '2019-05-25').perform }
+
+        Then { expect(output[:status]).to eq 'OK' }
+        And { expect(output[:shifts]).to eq [] }
+      end
+
+      context 'all maxed' do
+        # Stub to for #max? to return true
+        When { allow_any_instance_of(Shift).to receive(:max?).and_return(true) }
+        When(:output) { AvailableShiftsApi.new('2018-05-25', '2018-05-25').perform }
+
+        Then { expect(output[:status]).to eq 'OK' }
+        And { expect(output[:shifts]).to eq [] }
+      end
+    end
+  end
+end

--- a/spec/services/available_shifts_api_spec.rb
+++ b/spec/services/available_shifts_api_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AvailableShiftsApi do
       end
 
       context 'all maxed' do
-        # Stub to for #max? to return true
+        # Stub for #max? to return true
         When { allow_any_instance_of(Shift).to receive(:max?).and_return(true) }
         When(:output) { AvailableShiftsApi.new('2018-05-25', '2018-05-25').perform }
 


### PR DESCRIPTION
https://trello.com/c/Qu70FkAQ

## Why is this change necessary?

- Development is exclusive to contributors

## How does it address the issue?

- Other developers can create Third-Party applications through the use of public APIs

## What side effects does this change have?

- None