### PR TITLE
Display shifts summary of a deliverer

### DIFF
--- a/app/assets/stylesheets/base/default.scss
+++ b/app/assets/stylesheets/base/default.scss
@@ -95,3 +95,7 @@ table {
 .bottom-buffer { margin-bottom:20px; }
 
 .top-buffer { margin-top:20px; }
+
+table.borderless td {
+    border-top: none !important;
+}

--- a/app/controllers/deliverers_controller.rb
+++ b/app/controllers/deliverers_controller.rb
@@ -9,6 +9,8 @@ class DeliverersController < ApplicationController
     @deliverer = Deliverer.find(params[:id])
     today = Time.zone.today
     @range = (today - 29).at_beginning_of_day..today.at_end_of_day
+
+    # To use as queue
     @shifts = @deliverer.shifts.where(start_time: @range).order('start_time ASC').to_a
   end
 

--- a/app/controllers/deliverers_controller.rb
+++ b/app/controllers/deliverers_controller.rb
@@ -53,7 +53,7 @@ class DeliverersController < ApplicationController
     if @deliverer.update(deliverer_params)
       flash[:success] = 'Successfully updated a deliverer!'
 
-      redirect_to deliverers_path
+      redirect_to deliverer_path(params[:id])
     else
       errors = @deliverer.errors unless @deliverer.valid?
 

--- a/app/controllers/deliverers_controller.rb
+++ b/app/controllers/deliverers_controller.rb
@@ -1,7 +1,15 @@
 class DeliverersController < ApplicationController
-  # GET /deliverers/show
+  # GET /deliverers
   def index
     @deliverers = Deliverer.all
+  end
+
+  # GET /deliverers/show
+  def show
+    @deliverer = Deliverer.find(params[:id])
+    today = Time.zone.today
+    @range = (today - 29).at_beginning_of_day..today.at_end_of_day
+    @shifts = @deliverer.shifts.where(start_time: @range).order('start_time ASC').to_a
   end
 
   # GET /deliverers/new

--- a/app/controllers/deliverers_controller.rb
+++ b/app/controllers/deliverers_controller.rb
@@ -51,7 +51,7 @@ class DeliverersController < ApplicationController
     @deliverer = Deliverer.find(params[:id])
 
     if @deliverer.update(deliverer_params)
-      flash[:success] = 'Successfully updated a deliverer!'
+      flash[:success] = 'Successfully updated deliverer\'s info!'
 
       redirect_to deliverer_path(params[:id])
     else

--- a/app/controllers/deliverers_controller.rb
+++ b/app/controllers/deliverers_controller.rb
@@ -5,14 +5,18 @@ class DeliverersController < ApplicationController
   end
 
   # GET /deliverers/show
+  # :reek:TooManyStatements
+  # rubocop:disable Metrics/AbcSize
   def show
     @deliverer = Deliverer.find(params[:id])
     today = Time.zone.today
     @range = (today - 29).at_beginning_of_day..today.at_end_of_day
 
-    # To use as queue
-    @shifts = @deliverer.shifts.where(start_time: @range).order('start_time ASC').to_a
+    shifts = @deliverer.shifts.where(start_time: @range).order('start_time ASC')
+
+    @shift_groups = shifts.group_by { |shf| (shf.start_time.to_date - @range.begin.to_date).to_i }
   end
+  # rubocop:enable Metrics/AbcSize
 
   # GET /deliverers/new
   # page to add

--- a/app/helpers/deliverers_helper.rb
+++ b/app/helpers/deliverers_helper.rb
@@ -7,13 +7,17 @@ module DeliverersHelper
   # :reek:TooManyStatements
   def shifts_on_date(queue, date)
     shifts = []
+
+    # Dequeue shifts on given date
     while !queue.empty?
       head = queue.first
 
+      # Break when head element is after given date
       break if head.start_time >= date.at_end_of_day
 
       shifts << queue.shift
     end
+
     shifts
   end
 

--- a/app/helpers/deliverers_helper.rb
+++ b/app/helpers/deliverers_helper.rb
@@ -1,2 +1,38 @@
 module DeliverersHelper
+  def month_range
+    today = Time.zone.today
+    (today - 29)..today
+  end
+
+  # :reek:TooManyStatements
+  def shifts_on_date(queue, date)
+    shifts = []
+    while !queue.empty?
+      head = queue.first
+
+      break if head.start_time >= date.at_end_of_day
+
+      shifts << queue.shift
+    end
+    shifts
+  end
+
+  def time_range_to_s(shifts)
+    shifts.map do |shift|
+      "#{shift.start_time.strftime('%H:%M %p')} - #{shift.end_time.strftime('%H:%M %p')}"
+    end
+  end
+
+  # :reek:TooManyStatements
+  def time_taken(shifts)
+    total_time = 0
+
+    shifts.each do |shift|
+      total_time += shift.end_time - shift.start_time
+    end
+
+    hours = total_time / 3600.0
+    return '0' if hours <= 0
+    hours.to_s
+  end
 end

--- a/app/helpers/deliverers_helper.rb
+++ b/app/helpers/deliverers_helper.rb
@@ -4,23 +4,6 @@ module DeliverersHelper
     (today - 29)..today
   end
 
-  # :reek:TooManyStatements
-  def shifts_on_date(queue, date)
-    shifts = []
-
-    # Dequeue shifts on given date
-    while !queue.empty?
-      head = queue.first
-
-      # Break when head element is after given date
-      break if head.start_time >= date.at_end_of_day
-
-      shifts << queue.shift
-    end
-
-    shifts
-  end
-
   def time_range_to_s(shifts)
     shifts.map do |shift|
       "#{shift.start_time.strftime('%H:%M %p')} - #{shift.end_time.strftime('%H:%M %p')}"

--- a/app/views/deliverers/_deliverers_table.html.erb
+++ b/app/views/deliverers/_deliverers_table.html.erb
@@ -12,7 +12,7 @@
   <% @deliverers.each do |deliverer| %>
     <tr>
       <th><%= deliverer.id %></th>
-      <td><%= link_to deliverer.name, edit_deliverer_path(deliverer) %></td>
+      <td><%= link_to deliverer.name, deliverer_path(deliverer) %></td>
       <td><%= deliverer.phone %></td>
       <td><%= deliverer.vehicle.capitalize %></td>
       <td><%= deliverer.active_to_s %></td>

--- a/app/views/deliverers/_show_shifts.html.erb
+++ b/app/views/deliverers/_show_shifts.html.erb
@@ -7,13 +7,11 @@
     </tr>
   </thead>
 
-  <% total_time_taken = time_taken(@shifts) %>
-
-  <% month_range.each do |day|%>
+  <% month_range.each_with_index do |day, index|%>
     <tr>
       <th><%= day.strftime("%e %b")%></th>
       <td>
-        <% current = shifts_on_date(@shifts, day) %>
+        <% current = @shift_groups[index] || [] %>
         <%= time_range_to_s(current).join(tag.br).html_safe %>
       </td>
       <td class="text-center">
@@ -23,6 +21,6 @@
   <% end %>
   <tr>
     <th colspan=2 align=right>Total</th>
-    <td class="text-center"><%= total_time_taken %></td>
+    <td class="text-center"><%= time_taken(@shift_groups.values.flatten) %></td>
   </tr>
 </table>

--- a/app/views/deliverers/_show_shifts.html.erb
+++ b/app/views/deliverers/_show_shifts.html.erb
@@ -1,0 +1,28 @@
+<table class="table">
+  <thead class="thead-light">
+    <tr>
+      <th>Last 30 days</th>
+      <th>Shifts</th>
+      <th class="text-center">Duration (Hr)</th>
+    </tr>
+  </thead>
+
+  <% total_time_taken = time_taken(@shifts) %>
+
+  <% month_range.each do |day|%>
+    <tr>
+      <th><%= day.strftime("%e %b")%></th>
+      <td>
+        <% current = shifts_on_date(@shifts, day) %>
+        <%= time_range_to_s(current).join(tag.br).html_safe %>
+      </td>
+      <td class="text-center">
+        <%= time_taken(current) %>
+      </td>
+    </tr>
+  <% end %>
+  <tr>
+    <th colspan=2 align=right>Total</th>
+    <td class="text-center"><%= total_time_taken %></td>
+  </tr>
+</table>

--- a/app/views/deliverers/show.html.erb
+++ b/app/views/deliverers/show.html.erb
@@ -24,7 +24,7 @@
             </tr>
             <tr>
               <td>Vehicle:</td>
-              <td><%= @deliverer.vehicle %></td>
+              <td><%= @deliverer.vehicle.capitalize.to_s %></td>
             </tr>
             <tr>
               <td>Status:</td>

--- a/app/views/deliverers/show.html.erb
+++ b/app/views/deliverers/show.html.erb
@@ -1,0 +1,36 @@
+<div class="container">
+  <div class="row top-buffer">
+    <div class="col-md-offset-2 col-md-8">
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            <%= @deliverer.name %>
+          </h3>
+        </div>
+        <div class="panel-body">
+
+          <table class="table borderless" style="width:auto;">
+            <tr>
+              <td>Phone:</td>
+              <td><%= @deliverer.phone %></td>
+            </tr>
+            <tr>
+              <td>Vehicle:</td>
+              <td><%= @deliverer.vehicle %></td>
+            </tr>
+            <tr>
+              <td>Status:</td>
+              <td><%= @deliverer.active_to_s %></td>
+            </tr>
+          </table>
+
+        </div>
+
+        <%= render 'show_shifts'%>
+
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/deliverers/show.html.erb
+++ b/app/views/deliverers/show.html.erb
@@ -2,6 +2,8 @@
   <div class="row top-buffer">
     <div class="col-md-offset-2 col-md-8">
 
+      <%= render "shared/flash_messages" %>
+
       <div class="panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title">

--- a/app/views/deliverers/show.html.erb
+++ b/app/views/deliverers/show.html.erb
@@ -14,6 +14,11 @@
             <tr>
               <td>Phone:</td>
               <td><%= @deliverer.phone %></td>
+              <td width=100% class="text-center">
+                <%= button_to edit_deliverer_path(@deliverer), method: :get, class: "btn-xs" do %>
+                  <span class="glyphicon glyphicon-edit"></span> Edit
+                <% end %>
+              </td>
             </tr>
             <tr>
               <td>Vehicle:</td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     get 'signup', to: 'devise/registrations#new'
   end
 
-  resources :deliverers, only: %i[index new create edit update]
+  resources :deliverers, only: %i[index new create edit update show]
   resources :shifts, only: %i[index new create edit update]
 
   resources :assignments, only: %i[index new create]

--- a/spec/controllers/deliverers_controller_spec.rb
+++ b/spec/controllers/deliverers_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe DeliverersController, type: :controller do
               as: :json
       end
 
-      Then { is_expected.to redirect_to deliverers_path }
+      Then { is_expected.to redirect_to deliverer_path(deliverer.id) }
     end
 
     context 'with invalid attributes' do

--- a/spec/controllers/deliverers_controller_spec.rb
+++ b/spec/controllers/deliverers_controller_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe DeliverersController, type: :controller do
 
       # Inspect view element
       And { expect(response.body).to match(deliverer.name) }
-      And { expect(response.body).to match(deliverer.phone) }
-      And { expect(response.body).to match(deliverer.vehicle) }
+      And { expect(response.body).to match(deliverer.phone.to_s) }
+      And { expect(response.body).to match(deliverer.vehicle.capitalize.to_s) }
       And { expect(response.body).to match(deliverer.active_to_s) }
       And do
         expect(response.body).to(

--- a/spec/helpers/deliverers_helper_spec.rb
+++ b/spec/helpers/deliverers_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe DeliverersHelper, type: :helper do
+  describe '#shifts_on_date' do
+    Given!(:shift_today) do
+      time = Time.zone.now - 2.days
+      FactoryGirl.create(:shift, start_time: time, end_time: time + 2.hours)
+    end
+    Given!(:shift_tomorrow) do
+      time = Time.zone.now - 1.day
+      FactoryGirl.create(:shift, start_time: time, end_time: time + 2.hours)
+    end
+
+    Then do
+      expect(
+        shifts_on_date([shift_today, shift_tomorrow], (Time.zone.today - 2.days))
+      ).to eq [shift_today]
+    end
+  end
+
+  describe '#time_range_to_s' do
+    Given!(:shifts) { FactoryGirl.create_list(:shift, 2) }
+
+    When(:output) { time_range_to_s(shifts) }
+
+    Then do
+      expect(output).to(
+        eq ["#{shifts[0].start_time.strftime('%H:%M %p')} -" +
+              " #{shifts[0].end_time.strftime('%H:%M %p')}",
+            "#{shifts[1].start_time.strftime('%H:%M %p')} -" +
+              " #{shifts[1].end_time.strftime('%H:%M %p')}"]
+      )
+    end
+  end
+
+  describe '#time_taken' do
+    context 'shift exist' do
+      Given!(:shifts) { FactoryGirl.create_list(:shift, 2) }
+
+      Then(:output) { expect(time_taken(shifts)).to eq '4.0' }
+    end
+
+    context 'no shift exist' do
+      Then(:output) { expect(time_taken([])).to eq '0' }
+    end
+  end
+end

--- a/spec/helpers/deliverers_helper_spec.rb
+++ b/spec/helpers/deliverers_helper_spec.rb
@@ -1,23 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe DeliverersHelper, type: :helper do
-  describe '#shifts_on_date' do
-    Given!(:shift_today) do
-      time = Time.zone.now - 2.days
-      FactoryGirl.create(:shift, start_time: time, end_time: time + 2.hours)
-    end
-    Given!(:shift_tomorrow) do
-      time = Time.zone.now - 1.day
-      FactoryGirl.create(:shift, start_time: time, end_time: time + 2.hours)
-    end
-
-    Then do
-      expect(
-        shifts_on_date([shift_today, shift_tomorrow], (Time.zone.today - 2.days))
-      ).to eq [shift_today]
-    end
-  end
-
   describe '#time_range_to_s' do
     Given!(:shifts) { FactoryGirl.create_list(:shift, 2) }
 


### PR DESCRIPTION
https://trello.com/c/gFpVXYjL

## Why is this change necessary?

- There is no way to see a deliverer's activities

## How does it address the issue?

- Deliverer summary page show a deliverer info, along with his past 30 days shifts